### PR TITLE
Allow building docker image without first running run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:4
 COPY . /iccmobile
 WORKDIR /iccmobile
 
-RUN cd iowacodecamp-mobile; npm install; ./node_modules/ember-cli/bin/ember build; cd ..
+RUN cd iowacodecamp-mobile; npm install; ./node_modules/bower/bin/bower --allow-root install; ./node_modules/ember-cli/bin/ember build; cd ..
 RUN cd iccmobile-server; npm install; mkdir views; cd views; cp ../../iowacodecamp-mobile/dist/index.html index.hbs; cd ..; mkdir public; cd public; cp -r ../../iowacodecamp-mobile/dist/assets .; cp -r ../../iowacodecamp-mobile/dist/fonts .; cp -r ../../iowacodecamp-mobile/dist/images .; cd ..
 
 EXPOSE  8080

--- a/iowacodecamp-mobile/package.json
+++ b/iowacodecamp-mobile/package.json
@@ -35,7 +35,6 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.4.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",


### PR DESCRIPTION
I did not read the README.md and instead tried to first build the docker image. I was unable to do so because of the bower issue. I am not sure if this is desired but it did allow me to build the image and run it locally (previously it would fail and only work once the run.sh had been executed).